### PR TITLE
Robustness: cache resilience, schema validation, dedup, tag sanitization

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -10,6 +10,10 @@ on:
       - 'static/data/projects/**'
   workflow_dispatch:
 
+concurrency:
+  group: update-data
+  cancel-in-progress: false
+
 jobs:
   update-data:
     # Skip if triggered by bot to prevent loops
@@ -27,9 +31,10 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Fetch GitHub data
+      - name: Fetch repository data
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLAB_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         run: node scripts/fetch-github-data.js
         timeout-minutes: 5
 
@@ -50,5 +55,7 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
           git add static/data/github-cache.json static/data/projects/ static/data/embeddings.json static/logos/ .github/ISSUE_TEMPLATE/
-          git diff --staged --quiet || git commit -m "chore: update GitHub data cache"
+          git diff --staged --quiet && echo "No changes to commit" && exit 0
+          git commit -m "chore: update GitHub data cache"
+          git pull --rebase origin main
           git push

--- a/.github/workflows/validate-projects.yml
+++ b/.github/workflows/validate-projects.yml
@@ -1,0 +1,24 @@
+name: Validate Project Data
+
+on:
+  pull_request:
+    paths:
+      - 'static/data/projects/**'
+      - 'scripts/lib/**'
+      - 'scripts/validate-projects.js'
+  workflow_dispatch:
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Validate project data
+        run: node scripts/validate-projects.js

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
 	"type": "module",
 	"scripts": {
 		"build:projects": "node scripts/build-projects.js",
+		"validate": "node scripts/validate-projects.js",
 		"predev": "node scripts/build-projects.js",
 		"dev": "vite dev",
 		"prebuild": "node scripts/build-projects.js",

--- a/scripts/fetch-github-data.js
+++ b/scripts/fetch-github-data.js
@@ -16,7 +16,7 @@
  * Public repos work without tokens, just with lower rate limits.
  */
 
-import { writeFileSync } from 'fs';
+import { writeFileSync, readFileSync, existsSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { loadProjects } from './lib/projects-store.js';
@@ -190,8 +190,21 @@ async function main() {
 	console.log('');
 
 	const projects = loadProjects();
+	const cachePath = join(__dirname, '..', 'static', 'data', 'github-cache.json');
 
-	const githubData = {};
+	// Start from the existing cache so a transient API failure keeps the
+	// previous data for that project instead of dropping it from the site.
+	let githubData = {};
+	if (existsSync(cachePath)) {
+		try {
+			githubData = JSON.parse(readFileSync(cachePath, 'utf-8'));
+		} catch {
+			console.warn('Could not parse existing cache, starting fresh');
+		}
+	}
+
+	let fetched = 0;
+	let keptStale = 0;
 
 	for (const project of projects) {
 		const provider = getProvider(project.github);
@@ -205,23 +218,37 @@ async function main() {
 			const data = provider === 'gitlab' ? await fetchGitLab(project) : await fetchGitHub(project);
 			if (data) {
 				githubData[project.id] = data;
+				fetched++;
 				const versionInfo = data.releaseVersion ? ` (${data.releaseVersion})` : '';
 				console.log(`  ✓ ${data.stars} stars${versionInfo}`);
+			} else if (githubData[project.id]) {
+				keptStale++;
+				console.warn(`  ✗ Fetch returned nothing, keeping cached data for ${project.name}`);
 			} else {
-				console.warn(`  ✗ Failed to fetch repo data`);
+				console.warn(`  ✗ Failed to fetch repo data and no cached data exists`);
 			}
 		} catch (error) {
-			console.error(`  ✗ Error fetching ${project.name}:`, error.message);
+			if (githubData[project.id]) {
+				keptStale++;
+				console.warn(`  ✗ Error fetching ${project.name} (${error.message}), keeping cached data`);
+			} else {
+				console.error(`  ✗ Error fetching ${project.name}:`, error.message);
+			}
 		}
 
 		// Small delay to be nice to the APIs
 		await new Promise(resolve => setTimeout(resolve, 100));
 	}
 
-	const cachePath = join(__dirname, '..', 'static', 'data', 'github-cache.json');
+	// Prune cache entries for projects that no longer exist
+	const ids = new Set(projects.map(p => p.id));
+	for (const id of Object.keys(githubData)) {
+		if (!ids.has(id)) delete githubData[id];
+	}
+
 	writeFileSync(cachePath, JSON.stringify(githubData, null, '\t'));
 	console.log(`\nWrote cache to ${cachePath}`);
-	console.log(`Cached ${Object.keys(githubData).length}/${projects.length} projects`);
+	console.log(`${fetched} fetched, ${keptStale} kept from cache, ${Object.keys(githubData).length}/${projects.length} total cached`);
 }
 
 main().catch(console.error);

--- a/scripts/lib/constants.js
+++ b/scripts/lib/constants.js
@@ -1,0 +1,22 @@
+/**
+ * Shared constants for the project data pipeline.
+ * Centralized so the process scripts, validator and link checker agree.
+ */
+
+// A project id is a lowercase slug; it also serves as the filename.
+export const ID_PATTERN = /^[a-z0-9-]+$/;
+
+// Allowed characters in a tag: lowercase letters, digits, spaces and hyphens.
+export const TAG_ALLOWED = /[^a-z0-9 -]/g;
+
+// Fields that must be present and non-empty on every project.
+export const REQUIRED_FIELDS = ['id', 'name', 'tagline', 'github', 'tags'];
+
+// The repository URL field (named `github` for historical reasons; holds any repo URL).
+export const REPO_FIELD = 'github';
+
+// Optional fields that, when present, must be valid URLs (logo may also be a local /logos/ path).
+export const OPTIONAL_URL_FIELDS = ['docs', 'pypi', 'condaForge', 'homepage', 'example', 'logo'];
+
+// Every URL-bearing field (used by the link checker and validator).
+export const ALL_URL_FIELDS = [REPO_FIELD, ...OPTIONAL_URL_FIELDS];

--- a/scripts/lib/validate.js
+++ b/scripts/lib/validate.js
@@ -1,0 +1,120 @@
+/**
+ * Validation helpers for project data.
+ * Used by scripts/validate-projects.js (CI + local) and by process-submission
+ * as a final guard before a PR is opened.
+ */
+
+import {
+	ID_PATTERN,
+	REQUIRED_FIELDS,
+	OPTIONAL_URL_FIELDS,
+	REPO_FIELD,
+	TAG_ALLOWED
+} from './constants.js';
+
+/** True for a syntactically valid http(s) URL. */
+export function isValidHttpUrl(value) {
+	try {
+		const url = new URL(value);
+		return url.protocol === 'http:' || url.protocol === 'https:';
+	} catch {
+		return false;
+	}
+}
+
+/** Normalize a repo URL for duplicate detection (lowercase host, strip .git / trailing slash). */
+export function normalizeRepoUrl(value) {
+	try {
+		const url = new URL(value);
+		const host = url.host.toLowerCase();
+		const path = url.pathname.replace(/\.git$/, '').replace(/\/+$/, '');
+		return `${host}${path}`.toLowerCase();
+	} catch {
+		return (value || '').trim().toLowerCase();
+	}
+}
+
+/** Sanitize a single tag to the allowed character set; returns '' if nothing remains. */
+export function sanitizeTag(tag) {
+	return String(tag)
+		.toLowerCase()
+		.replace(TAG_ALLOWED, '')
+		.replace(/\s+/g, ' ')
+		.trim();
+}
+
+/**
+ * Validate a single project object. Returns an array of error strings (empty if valid).
+ */
+export function validateProject(project) {
+	const errors = [];
+	const label = project?.id || project?.name || '(unknown)';
+
+	for (const field of REQUIRED_FIELDS) {
+		if (project[field] === undefined || project[field] === null || project[field] === '') {
+			errors.push(`${label}: missing required field "${field}"`);
+		}
+	}
+
+	if (project.id && !ID_PATTERN.test(project.id)) {
+		errors.push(`${label}: id "${project.id}" must match ${ID_PATTERN}`);
+	}
+
+	if (project.github && !isValidHttpUrl(project.github)) {
+		errors.push(`${label}: ${REPO_FIELD} "${project.github}" is not a valid URL`);
+	}
+
+	if (project.tags !== undefined) {
+		if (!Array.isArray(project.tags) || project.tags.length === 0) {
+			errors.push(`${label}: tags must be a non-empty array`);
+		} else if (project.tags.some((t) => typeof t !== 'string' || t.trim() === '')) {
+			errors.push(`${label}: tags must all be non-empty strings`);
+		}
+	}
+
+	for (const field of OPTIONAL_URL_FIELDS) {
+		const value = project[field];
+		if (value === undefined) continue;
+		// logo may be a local path served from /logos/
+		if (field === 'logo' && typeof value === 'string' && value.startsWith('/logos/')) continue;
+		if (!isValidHttpUrl(value)) {
+			errors.push(`${label}: ${field} "${value}" is not a valid URL`);
+		}
+	}
+
+	return errors;
+}
+
+/**
+ * Validate an array of projects, including cross-project checks
+ * (unique ids, unique repository URLs). Returns an array of error strings.
+ */
+export function validateAll(projects) {
+	const errors = [];
+
+	for (const project of projects) {
+		errors.push(...validateProject(project));
+	}
+
+	const seenIds = new Map();
+	const seenRepos = new Map();
+	for (const project of projects) {
+		if (project.id) {
+			if (seenIds.has(project.id)) {
+				errors.push(`Duplicate id "${project.id}" (also ${seenIds.get(project.id)})`);
+			} else {
+				seenIds.set(project.id, project.name || project.id);
+			}
+		}
+		if (project.github) {
+			const key = normalizeRepoUrl(project.github);
+			if (seenRepos.has(key)) {
+				errors.push(`Duplicate repository "${project.github}" in "${project.id}" and "${seenRepos.get(key)}"`);
+			} else {
+				seenRepos.set(key, project.id);
+			}
+		}
+	}
+
+	return errors;
+}

--- a/scripts/process-submission.js
+++ b/scripts/process-submission.js
@@ -10,6 +10,7 @@ import { writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { loadProjects, writeProject } from './lib/projects-store.js';
+import { sanitizeTag, normalizeRepoUrl, validateProject } from './lib/validate.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -137,11 +138,12 @@ function parseSubmission(issueBody) {
 	// Extract tags from checkboxes
 	const checkedTags = extractCheckedTags(issueBody, 'Select all tags that apply');
 	const customTagsRaw = extractField(issueBody, 'Additional Tags');
-	const customTags = customTagsRaw
-		? customTagsRaw.split(',').map(t => t.trim().toLowerCase()).filter(Boolean)
-		: [];
+	const customTags = customTagsRaw ? customTagsRaw.split(',') : [];
 
-	project.tags = [...new Set([...checkedTags, ...customTags])];
+	// Sanitize every tag to the allowed charset so custom tags can't corrupt
+	// the generated issue templates (see sync-issue-templates.js).
+	const tags = [...checkedTags, ...customTags].map(sanitizeTag).filter(Boolean);
+	project.tags = [...new Set(tags)];
 
 	if (project.tags.length === 0) {
 		throw new Error('At least one tag is required');
@@ -190,6 +192,9 @@ function parseSubmission(issueBody) {
 
 	// Generate ID from name
 	project.id = project.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
+	if (!project.id) {
+		throw new Error(`Could not derive a valid project id from the name "${project.name}". Please use a name with letters or numbers.`);
+	}
 
 	// Extract logo
 	const logoContent = extractField(issueBody, 'Logo');
@@ -204,9 +209,16 @@ function parseSubmission(issueBody) {
 function addProject(project) {
 	const projects = loadProjects();
 
-	// Check for duplicates
+	// Check for duplicate id
 	if (projects.some(p => p.id === project.id)) {
 		throw new Error(`Project with ID '${project.id}' already exists`);
+	}
+
+	// Check for duplicate repository (same repo submitted under a different name)
+	const repoKey = normalizeRepoUrl(project.github);
+	const existingRepo = projects.find(p => normalizeRepoUrl(p.github) === repoKey);
+	if (existingRepo) {
+		throw new Error(`Repository ${project.github} is already listed as "${existingRepo.name}"`);
 	}
 
 	// Write the project to its own source file
@@ -228,6 +240,12 @@ try {
 	// Store the submitter's GitHub handle
 	if (issueAuthor) {
 		project.submittedBy = issueAuthor;
+	}
+
+	// Final guard: the assembled project must satisfy the data schema
+	const schemaErrors = validateProject(project);
+	if (schemaErrors.length > 0) {
+		throw new Error(`Invalid project data:\n\n${schemaErrors.join('\n')}`);
 	}
 
 	addProject(project);

--- a/scripts/process-update.js
+++ b/scripts/process-update.js
@@ -10,6 +10,7 @@ import { writeFileSync } from 'fs';
 import { fileURLToPath } from 'url';
 import { dirname } from 'path';
 import { loadProjects, writeProject } from './lib/projects-store.js';
+import { sanitizeTag } from './lib/validate.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -150,14 +151,12 @@ function parseUpdate(issueBody) {
 	if (homepage) updates.homepage = homepage;
 	if (example) updates.example = example;
 
-	// Tags from checkboxes
+	// Tags from checkboxes (sanitized to the allowed charset)
 	const checkedTags = extractCheckedTags(issueBody, 'Select new tags');
 	const customTagsRaw = extractField(issueBody, 'Additional Tags');
-	const customTags = customTagsRaw
-		? customTagsRaw.split(',').map(t => t.trim().toLowerCase()).filter(Boolean)
-		: [];
+	const customTags = customTagsRaw ? customTagsRaw.split(',') : [];
 
-	const allTags = [...checkedTags, ...customTags];
+	const allTags = [...new Set([...checkedTags, ...customTags].map(sanitizeTag).filter(Boolean))];
 	if (allTags.length > 0) {
 		updates.tags = allTags;
 	}

--- a/scripts/sync-issue-templates.js
+++ b/scripts/sync-issue-templates.js
@@ -32,7 +32,7 @@ function syncTagCheckboxes(templatePath, tags) {
 	let template = readFileSync(templatePath, 'utf-8');
 
 	// Build checkbox options YAML
-	const checkboxOptions = tags.map(tag => `        - label: ${tag}`).join('\n');
+	const checkboxOptions = tags.map(tag => `        - label: "${tag}"`).join('\n');
 
 	// Replace the options under "id: tags" checkbox section
 	template = template.replace(
@@ -74,7 +74,7 @@ function syncUpdateTemplate(projects, tags) {
 	);
 
 	// Sync tag checkboxes
-	const checkboxOptions = tags.map(tag => `        - label: ${tag}`).join('\n');
+	const checkboxOptions = tags.map(tag => `        - label: "${tag}"`).join('\n');
 
 	template = template.replace(
 		/(id: tags\n[\s\S]*?options:\n)([\s\S]*?)(\n\n  - type:)/,

--- a/scripts/validate-projects.js
+++ b/scripts/validate-projects.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+/**
+ * Validate all project data files. Run in CI on PRs that touch project data,
+ * and locally before relying on the catalog. Exits non-zero on any problem,
+ * so malformed data is caught before it reaches the site.
+ */
+
+import { readdirSync, readFileSync } from 'fs';
+import { basename, extname } from 'path';
+import { loadProjects, PROJECTS_DIR, projectFilePath } from './lib/projects-store.js';
+import { validateAll } from './lib/validate.js';
+
+const errors = [];
+
+// Each file's name must match the project's id (so the slug stays the filename).
+for (const file of readdirSync(PROJECTS_DIR).filter((f) => extname(f) === '.json')) {
+	const id = basename(file, '.json');
+	const path = projectFilePath(id);
+	let project;
+	try {
+		project = JSON.parse(readFileSync(path, 'utf-8'));
+	} catch (e) {
+		errors.push(`${file}: invalid JSON (${e.message})`);
+		continue;
+	}
+	if (project.id !== id) {
+		errors.push(`${file}: id "${project.id}" does not match filename`);
+	}
+}
+
+errors.push(...validateAll(loadProjects()));
+
+if (errors.length > 0) {
+	console.error(`✗ Project validation failed with ${errors.length} error(s):\n`);
+	for (const e of errors) console.error(`  - ${e}`);
+	process.exit(1);
+}
+
+console.log('✓ All project files are valid');


### PR DESCRIPTION
Quick-win robustness batch (rebased onto main after #116 merged; supersedes the auto-closed #117).

## Changes
1. **Cache resilience** (`fetch-github-data.js`): cache is loaded first and only overwritten on a successful fetch. A transient API failure keeps the project's previous data instead of dropping it; stale entries for removed projects are pruned.
3. **Schema validation**: `scripts/lib/validate.js` + `scripts/validate-projects.js` + `validate-projects.yml` PR check + `npm run validate` + a final guard in `process-submission.js`. Shared constants in `scripts/lib/constants.js`.
4. **Duplicate repo + id guard** (`process-submission.js`): rejects an already-listed repo URL and names that produce an empty id.
5. **Tag sanitization** (`process-submission/update.js`): custom tags sanitized to `[a-z0-9 -]`; labels quoted in `sync-issue-templates.js`.
8. **update-data workflow**: `concurrency` group, `git pull --rebase` before push, optional `GITLAB_TOKEN`.

## Verified locally
- `npm run check` clean; `npm run validate` passes; negative test fails as expected.
- Adversarial submissions (dup repo, empty id, dirty tags) handled correctly.
- Cache resilience: forced 404 keeps prior entry (24 fetched, 1 kept).