### PR TITLE
Fix broken link checker (lychee config + error_map parsing)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -7,7 +7,7 @@ on:
   # Run on PRs that modify project data or content
   pull_request:
     paths:
-      - 'static/data/projects.json'
+      - 'static/data/projects/**'
       - 'src/routes/**/*.svelte'
       - 'src/routes/**/*.md'
   # Allow manual trigger
@@ -48,10 +48,10 @@ jobs:
             --exclude "^https://github\.com/pysimhub/pysimhub\.github\.io/issues/new"
             --exclude "^https://anaconda\.org"
             --exclude "^https://pypi\.org"
-            --format json
-            --output lychee-output.json
             './build/**/*.html'
             './static/data/projects.json'
+          format: json
+          output: lychee-output.json
           fail: false
           jobSummary: true
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -58,10 +58,25 @@ jobs:
       - name: DEBUG lychee output
         if: always()
         run: |
-          echo "=== top-level keys ==="
-          node -e 'const d=require("./lychee-output.json");console.log(Object.keys(d));console.log("fail_map keys:",d.fail_map?Object.keys(d.fail_map):"none");console.log("error_map keys:",d.error_map?Object.keys(d.error_map):"none")'
-          echo "=== first 2500 chars ==="
-          head -c 2500 lychee-output.json
+          node -e '
+            const d=require("./lychee-output.json");
+            const m=d.error_map||d.fail_map||{};
+            const byCode={};
+            let total=0;
+            const broken=[];
+            for(const src of Object.keys(m)){
+              for(const e of m[src]){
+                total++;
+                const code=(e.status&&typeof e.status==="object")?e.status.code:e.status;
+                byCode[code]=(byCode[code]||0)+1;
+                if(!code||code>=400) broken.push({url:e.url,code});
+              }
+            }
+            console.log("error_map total entries:",total);
+            console.log("by code:",JSON.stringify(byCode));
+            console.log("broken (code>=400 or falsy):",broken.length);
+            console.log("sample broken:",JSON.stringify(broken.slice(0,15),null,1));
+          '
 
       - name: Map broken links to submitters
         id: map-links

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -45,6 +45,7 @@ jobs:
             --accept 100..=399
             --timeout 30
             --max-retries 2
+            --root-dir ${{ github.workspace }}/build
             --exclude "^https://github\.com/pysimhub/pysimhub\.github\.io/issues/new"
             --exclude "^https://anaconda\.org"
             --exclude "^https://pypi\.org"
@@ -55,20 +56,12 @@ jobs:
           fail: false
           jobSummary: true
 
-      - name: DEBUG lychee output
-        if: always()
-        run: |
-          node -e '
-            const d=require("./lychee-output.json");
-            const m=d.error_map||{};
-            const firstSrc=Object.keys(m)[0];
-            console.log("first error_map source:",firstSrc);
-            console.log("raw first 3 entries:",JSON.stringify(m[firstSrc].slice(0,3),null,1));
-          '
-
+      # Always run: extracts only genuinely broken external links (lychee's
+      # error_map also includes unresolved local paths, which we ignore) and
+      # reports has_broken so later steps fire only on real breakage.
       - name: Map broken links to submitters
         id: map-links
-        if: steps.lychee.outputs.exit_code != 0
+        if: always()
         env:
           LYCHEE_OUTPUT: lychee-output.json
           WORKFLOW_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
@@ -76,7 +69,7 @@ jobs:
         run: node scripts/map-broken-links.js
 
       - name: Create issue with submitter mentions
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.map-links.outputs.has_broken == 'true'
         uses: actions/github-script@v9
         with:
           script: |
@@ -119,5 +112,5 @@ jobs:
             }
 
       - name: Fail workflow if links are broken
-        if: steps.lychee.outputs.exit_code != 0
+        if: steps.map-links.outputs.has_broken == 'true'
         run: exit 1

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -55,6 +55,14 @@ jobs:
           fail: false
           jobSummary: true
 
+      - name: DEBUG lychee output
+        if: always()
+        run: |
+          echo "=== top-level keys ==="
+          node -e 'const d=require("./lychee-output.json");console.log(Object.keys(d));console.log("fail_map keys:",d.fail_map?Object.keys(d.fail_map):"none");console.log("error_map keys:",d.error_map?Object.keys(d.error_map):"none")'
+          echo "=== first 2500 chars ==="
+          head -c 2500 lychee-output.json
+
       - name: Map broken links to submitters
         id: map-links
         if: steps.lychee.outputs.exit_code != 0

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -60,22 +60,10 @@ jobs:
         run: |
           node -e '
             const d=require("./lychee-output.json");
-            const m=d.error_map||d.fail_map||{};
-            const byCode={};
-            let total=0;
-            const broken=[];
-            for(const src of Object.keys(m)){
-              for(const e of m[src]){
-                total++;
-                const code=(e.status&&typeof e.status==="object")?e.status.code:e.status;
-                byCode[code]=(byCode[code]||0)+1;
-                if(!code||code>=400) broken.push({url:e.url,code});
-              }
-            }
-            console.log("error_map total entries:",total);
-            console.log("by code:",JSON.stringify(byCode));
-            console.log("broken (code>=400 or falsy):",broken.length);
-            console.log("sample broken:",JSON.stringify(broken.slice(0,15),null,1));
+            const m=d.error_map||{};
+            const firstSrc=Object.keys(m)[0];
+            console.log("first error_map source:",firstSrc);
+            console.log("raw first 3 entries:",JSON.stringify(m[firstSrc].slice(0,3),null,1));
           '
 
       - name: Map broken links to submitters

--- a/scripts/map-broken-links.js
+++ b/scripts/map-broken-links.js
@@ -40,33 +40,50 @@ function extractUrlsFromMarkdown(text) {
 	return [...new Set(urls)]; // dedupe
 }
 
+function isHttpUrl(url) {
+	return typeof url === 'string' && /^https?:\/\//.test(url);
+}
+
+/**
+ * Extract genuinely broken external links from lychee's JSON report.
+ * lychee groups failures per source file under `error_map` (older versions:
+ * `fail_map`). We keep only http(s) URLs, dropping lychee's noise from
+ * unresolved local/root-relative paths (e.g. "/logos/x.png"), which it cannot
+ * resolve on the filesystem but which work fine on the deployed site.
+ */
 function parseLycheeOutput(lycheeOutputPath) {
 	const content = readFileSync(lycheeOutputPath, 'utf-8');
 
-	// Handle both JSON array format and NDJSON (newline-delimited JSON)
+	let parsed;
 	try {
-		const parsed = JSON.parse(content);
-		// If it's the detailed JSON format with fail_map
-		if (parsed.fail_map) {
-			const brokenUrls = [];
-			for (const [source, failures] of Object.entries(parsed.fail_map)) {
-				for (const failure of failures) {
-					brokenUrls.push({
-						url: failure.url,
-						status: failure.status?.code || failure.status || 'unknown',
-						source
-					});
-				}
-			}
-			return brokenUrls;
-		}
-		// Simple array format
-		return parsed;
+		parsed = JSON.parse(content);
 	} catch {
-		// Try NDJSON format (one JSON object per line)
-		const lines = content.trim().split('\n').filter(Boolean);
-		return lines.map(line => JSON.parse(line));
+		// NDJSON fallback (one JSON object per line)
+		const lines = content.trim().split('\n').filter(Boolean).map(line => JSON.parse(line));
+		return dedupeByUrl(lines.filter(e => isHttpUrl(e.url)));
 	}
+
+	const map = parsed.error_map || parsed.fail_map || {};
+	const broken = [];
+	for (const [source, entries] of Object.entries(map)) {
+		for (const entry of entries) {
+			if (!isHttpUrl(entry.url)) continue; // skip unresolved local/relative paths
+			const status = (entry.status && typeof entry.status === 'object')
+				? (entry.status.code || entry.status.text || 'error')
+				: (entry.status || 'error');
+			broken.push({ url: entry.url, status, source });
+		}
+	}
+	return dedupeByUrl(broken);
+}
+
+function dedupeByUrl(links) {
+	const seen = new Set();
+	return links.filter(link => {
+		if (seen.has(link.url)) return false;
+		seen.add(link.url);
+		return true;
+	});
 }
 
 function findProjectForUrl(url, projects) {
@@ -193,24 +210,35 @@ if (!lycheeOutputPath) {
 	process.exit(1);
 }
 
+/** Report the broken-link count to the workflow so it can gate later steps. */
+function setOutput(hasBroken, count) {
+	if (process.env.GITHUB_OUTPUT) {
+		writeFileSync(process.env.GITHUB_OUTPUT, `has_broken=${hasBroken}\ncount=${count}\n`, { flag: 'a' });
+	}
+}
+
 try {
 	const projects = loadProjects();
 	const brokenLinks = parseLycheeOutput(lycheeOutputPath);
 
 	if (brokenLinks.length === 0) {
-		console.log('No broken links found.');
+		console.log('No broken external links found.');
+		setOutput(false, 0);
 		process.exit(0);
 	}
 
+	console.log(`Found ${brokenLinks.length} broken external link(s).`);
 	const issueBody = generateIssueBody(brokenLinks, projects, workflowUrl);
 
-	// Output to file if GITHUB_OUTPUT is set, otherwise print
+	// Output to file if requested, otherwise print
 	if (process.env.ISSUE_BODY_FILE) {
 		writeFileSync(process.env.ISSUE_BODY_FILE, issueBody);
 		console.log(`Issue body written to ${process.env.ISSUE_BODY_FILE}`);
 	} else {
 		console.log(issueBody);
 	}
+
+	setOutput(true, brokenLinks.length);
 } catch (error) {
 	console.error(`Error: ${error.message}`);
 	process.exit(1);


### PR DESCRIPTION
The weekly/PR link checker had been failing on every run, so broken project links went unreported.

## Root causes
1. **lychee-action config error**: `--format`/`--output` were passed in `args` while the action also sets them, causing `'output' is set in args as well as in the action configuration` before lychee even ran.
2. **error_map vs fail_map**: current lychee writes failures under `error_map` (not `fail_map`), so `map-broken-links.js` crashed with `brokenLinks is not iterable`.
3. **Local-path noise**: lychee's error_map also lists root-relative internal links (`/logos/x.png`, `/about`) it can't resolve on the filesystem (`url: "error:"`) - 311 false positives that work fine on the deployed site.

## Fix
- Move `format: json` / `output: lychee-output.json` to action inputs; add `--root-dir ${{ github.workspace }}/build` so internal links resolve.
- Rewrite `parseLycheeOutput` to read `error_map` (`fail_map` fallback), keep only http(s) URLs (dropping local-path noise), and dedupe.
- `map-broken-links.js` now reports `has_broken`/`count`; the create-issue and fail steps gate on `has_broken == 'true'`, so the workflow only fails / files an issue on genuinely broken external links, not on lychee's internal-path noise.
- Updated the PR trigger path to `static/data/projects/**` (the new per-file source).

## Verified
- Real run on this branch: green - lychee runs, internal links resolve, no genuine broken links → issue/fail steps correctly skipped.
- Unit-tested the parser: mixed error_map (404 + timeout + `error:` + file://) → only the 2 real http failures kept and deduped; noise-only input → `has_broken=false`.