### PR TITLE
Robust reprocessing: per-issue concurrency, reprocess-on-edit, verbatim errors

### DIFF
--- a/.github/workflows/process-removal.yml
+++ b/.github/workflows/process-removal.yml
@@ -2,22 +2,25 @@ name: Process Project Removal
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, edited]
   workflow_dispatch:
     inputs:
       issue_number:
         description: 'Issue number to process'
         required: true
 
+# Per-issue concurrency: a re-trigger for the same issue supersedes its own
+# in-flight run; different issues run in parallel.
 concurrency:
-  group: project-changes
-  cancel-in-progress: false
+  group: removal-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
 
 jobs:
   process-removal:
     if: >
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.label.name == 'removal' && !contains(github.event.issue.labels.*.name, 'pr-created'))
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.issue.labels.*.name, 'removal') &&
+       !contains(github.event.issue.labels.*.name, 'pr-created'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -54,6 +57,28 @@ jobs:
           ISSUE_BODY: ${{ steps.issue.outputs.body }}
           ISSUE_AUTHOR: ${{ steps.issue.outputs.author }}
         run: node scripts/process-removal.js
+        continue-on-error: true
+
+      - name: Comment on issue (processing error)
+        if: steps.process.outcome == 'failure'
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        with:
+          script: |
+            const fs = require('fs');
+            let msg = 'Unknown error occurred.';
+            try { msg = fs.readFileSync('process-error.txt', 'utf-8').trim() || msg; } catch {}
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: `❌ **Error processing removal request**\n\n${msg}\n\nEdit the issue to fix this and it will be reprocessed automatically.`
+            });
+
+      - name: Fail if processing error
+        if: steps.process.outcome == 'failure'
+        run: exit 1
 
       - name: Create Pull Request
         id: pr
@@ -106,14 +131,16 @@ jobs:
               title: `[Removal] ${{ steps.process.outputs.name }}`
             });
 
-      - name: Comment on issue (failure)
-        if: failure()
+      - name: Comment on issue (unexpected failure)
+        if: failure() && steps.process.outcome == 'success'
         uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.issue.outputs.number }},
-              body: `**Error processing removal request**\n\nPlease ensure you selected a valid project.\n\nSee the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: `❌ **Unexpected error**\n\nSomething went wrong while creating the PR.\n\nSee the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`
             });

--- a/.github/workflows/process-submission.yml
+++ b/.github/workflows/process-submission.yml
@@ -2,22 +2,26 @@ name: Process Project Submission
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, edited]
   workflow_dispatch:
     inputs:
       issue_number:
         description: 'Issue number to process'
         required: true
 
+# Scope concurrency to the issue: a re-trigger (edit/relabel) for the same
+# issue supersedes its own in-flight run, while different issues run in
+# parallel. Per-file project storage means concurrent issues never conflict.
 concurrency:
-  group: project-changes
-  cancel-in-progress: false
+  group: submission-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
 
 jobs:
   process-submission:
     if: >
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.label.name == 'submission' && !contains(github.event.issue.labels.*.name, 'pr-created'))
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.issue.labels.*.name, 'submission') &&
+       !contains(github.event.issue.labels.*.name, 'pr-created'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -53,31 +57,24 @@ jobs:
         env:
           ISSUE_BODY: ${{ steps.issue.outputs.body }}
           ISSUE_AUTHOR: ${{ steps.issue.outputs.author }}
-        run: |
-          node scripts/process-submission.js 2>&1 | tee process-output.txt
-          exit ${PIPESTATUS[0]}
+        run: node scripts/process-submission.js
         continue-on-error: true
-
-      - name: Check for processing errors
-        id: check-error
-        if: steps.process.outcome == 'failure'
-        run: |
-          ERROR_MSG=$(cat process-output.txt | grep -E "^ERROR=" | sed 's/ERROR=//' || echo "Unknown error occurred")
-          echo "error_message<<EOF" >> $GITHUB_OUTPUT
-          echo "$ERROR_MSG" >> $GITHUB_OUTPUT
-          echo "EOF" >> $GITHUB_OUTPUT
 
       - name: Comment on issue (processing error)
         if: steps.process.outcome == 'failure'
         uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         with:
           script: |
-            const errorMsg = `${{ steps.check-error.outputs.error_message }}`;
+            const fs = require('fs');
+            let msg = 'Unknown error occurred.';
+            try { msg = fs.readFileSync('process-error.txt', 'utf-8').trim() || msg; } catch {}
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.issue.outputs.number }},
-              body: `❌ **Error processing submission**\n\n**Issue:** ${errorMsg}\n\nPlease fix the issue and a maintainer will re-trigger the submission process.`
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: `❌ **Error processing submission**\n\n${msg}\n\nEdit the issue to fix this and it will be reprocessed automatically.`
             });
 
       - name: Fail if processing error

--- a/.github/workflows/process-update.yml
+++ b/.github/workflows/process-update.yml
@@ -2,22 +2,25 @@ name: Process Project Update
 
 on:
   issues:
-    types: [labeled]
+    types: [labeled, edited]
   workflow_dispatch:
     inputs:
       issue_number:
         description: 'Issue number to process'
         required: true
 
+# Per-issue concurrency: a re-trigger for the same issue supersedes its own
+# in-flight run; different issues run in parallel.
 concurrency:
-  group: project-changes
-  cancel-in-progress: false
+  group: update-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
 
 jobs:
   process-update:
     if: >
-      (github.event_name == 'workflow_dispatch') ||
-      (github.event.label.name == 'update' && !contains(github.event.issue.labels.*.name, 'pr-created'))
+      github.event_name == 'workflow_dispatch' ||
+      (contains(github.event.issue.labels.*.name, 'update') &&
+       !contains(github.event.issue.labels.*.name, 'pr-created'))
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -54,6 +57,28 @@ jobs:
           ISSUE_BODY: ${{ steps.issue.outputs.body }}
           ISSUE_AUTHOR: ${{ steps.issue.outputs.author }}
         run: node scripts/process-update.js
+        continue-on-error: true
+
+      - name: Comment on issue (processing error)
+        if: steps.process.outcome == 'failure'
+        uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
+        with:
+          script: |
+            const fs = require('fs');
+            let msg = 'Unknown error occurred.';
+            try { msg = fs.readFileSync('process-error.txt', 'utf-8').trim() || msg; } catch {}
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: `❌ **Error processing update**\n\n${msg}\n\nProtected fields (cannot be changed): \`id\`, \`name\`, \`github\`, \`submittedBy\`. Edit the issue to fix this and it will be reprocessed automatically.`
+            });
+
+      - name: Fail if processing error
+        if: steps.process.outcome == 'failure'
+        run: exit 1
 
       - name: Create Pull Request
         id: pr
@@ -104,14 +129,16 @@ jobs:
               title: `[Update] ${{ steps.process.outputs.name }}`
             });
 
-      - name: Comment on issue (failure)
-        if: failure()
+      - name: Comment on issue (unexpected failure)
+        if: failure() && steps.process.outcome == 'success'
         uses: actions/github-script@v9
+        env:
+          ISSUE_NUMBER: ${{ steps.issue.outputs.number }}
         with:
           script: |
             await github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              issue_number: ${{ steps.issue.outputs.number }},
-              body: `**Error processing update**\n\nPlease check your JSON format and ensure you're only updating allowed fields.\n\n**Protected fields (cannot be changed):** \`id\`, \`name\`, \`github\`, \`submittedBy\`\n\nSee the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`
+              issue_number: Number(process.env.ISSUE_NUMBER),
+              body: `❌ **Unexpected error**\n\nSomething went wrong while creating the PR.\n\nSee the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.`
             });

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ Thumbs.db
 
 # CI artifacts
 process-output.txt
+process-error.txt
 
 # Generated: merged from static/data/projects/*.json (source of truth)
 static/data/projects.json

--- a/scripts/process-removal.js
+++ b/scripts/process-removal.js
@@ -105,5 +105,7 @@ try {
 	}
 } catch (error) {
 	console.error(`ERROR=${error.message}`);
+	// Write the full (possibly multi-line) message for the workflow to post verbatim
+	writeFileSync('process-error.txt', error.message);
 	process.exit(1);
 }

--- a/scripts/process-submission.js
+++ b/scripts/process-submission.js
@@ -270,5 +270,7 @@ try {
 	}
 } catch (error) {
 	console.error(`ERROR=${error.message}`);
+	// Write the full (possibly multi-line) message for the workflow to post verbatim
+	writeFileSync('process-error.txt', error.message);
 	process.exit(1);
 }

--- a/scripts/process-update.js
+++ b/scripts/process-update.js
@@ -259,5 +259,7 @@ try {
 	}
 } catch (error) {
 	console.error(`ERROR=${error.message}`);
+	// Write the full (possibly multi-line) message for the workflow to post verbatim
+	writeFileSync('process-error.txt', error.message);
 	process.exit(1);
 }


### PR DESCRIPTION
Fixes the class of problem hit with the Raytrax submission (#122): a submission failed validation, was fixed, but couldn't be cleanly re-triggered (the run 'hung'/cancelled) and the error comment was empty.

## Root causes
- The global `concurrency: project-changes` (`cancel-in-progress: false`) cancels *pending* runs when a new one queues, so re-labeling produced cancelled 0-job runs that looked like hangs. That group only existed to serialize edits to the single projects.json, which the per-file refactor already made unnecessary.
- Editing the issue to fix it didn't re-trigger anything (workflow only listened to `labeled`).
- The error comment was built by grepping `^ERROR=` and interpolating into github-script, which dropped the multi-line URL-error detail (empty 'Invalid URLs found:').

## Changes (all three process workflows)
1. **Per-issue concurrency**: `group: <type>-${{ issue.number }}`, `cancel-in-progress: true`. A re-trigger for the same issue supersedes its own in-flight run (no hang); different issues run in parallel (safe thanks to per-file storage).
2. **Reprocess on edit**: trigger on `issues: [labeled, edited]`; the job `if` now checks the issue's current labels (has `<type>`, not `pr-created`). Fixing the issue body auto-reprocesses; once a PR exists it's skipped (no loop).
3. **Verbatim error feedback**: the process scripts write the full message to `process-error.txt`; the workflow posts it via `fs.readFileSync` (no grep/heredoc/interpolation). Removes the empty-message bug and a `${{ }}`-into-script injection. Error comments now say 'edit the issue and it will be reprocessed automatically'. Unified across submission/update/removal.

## Verified locally
- All three workflow YAMLs parse; scripts syntax-check.
- Invalid-URL submission now writes the full multi-line message to process-error.txt (the Raytrax case) and creates no project file.
- Valid lifecycle (submission/update/removal) unaffected.